### PR TITLE
Support Ansible filters

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout python3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 
 # Jinja2 and YAML for Jupyter
 
+## Update
+
+0.2.0a1 adds a loader for Ansible's built-in filters. Make sure you have 
+`ansible-core` installed in your environment, and then run this in a cell:
+
+```jupyter
+%jinja_load_ansible
+```
+
+`%jinja_load_ansible` takes one optional argument: a directory to search for
+additional Ansible plugins. To see if it works, run something like
+
+```jinja
+%%jinja
+{{ ""|md5 }}
+```
+
+----
+
 ### Please see [the full HTML version](https://nopdotcom.github.io/jinja-straight-demo.html).
 
 The rest of this file is just the `nbconvert` into Markdown; it's hard to read. See [the HTML version](https://nopdotcom.github.io/jinja-straight-demo.html).

--- a/jinja_yaml_magic/_load_ansible_filters.py
+++ b/jinja_yaml_magic/_load_ansible_filters.py
@@ -1,0 +1,18 @@
+# This is probably not the ideal way to gather Ansible filters, but it
+# works.
+#
+# Isolated to a separate file to avoid hitting critical mass of hackery
+# in one place.
+
+import ansible.plugins.loader as loader
+
+
+def _load_ansible_filters(plugin_root_dir="plugins/filter"):
+    # TODO: Figure out what that last argument really does
+    jl = loader.Jinja2Loader("FilterModule", "ansible.plugins.filter", None, ".")
+    jl.add_directory(plugin_root_dir)
+    filters = {}
+    for mod in jl.all():
+        for name, filter in mod.filters().items():
+            filters[name] = filter
+    return filters

--- a/jinja_yaml_magic/jinja_yaml_magic.py
+++ b/jinja_yaml_magic/jinja_yaml_magic.py
@@ -194,8 +194,8 @@ class JinjaMagics(Magics):
         """Find modified variables from the template run, and store them
         back in their source.
         """
-        vars = dict((k, v) for (k, v) in template.module.__dict__.items() if not k.startswith('_'))
-        for k, v in vars.items():
+        all_vars = dict((k, v) for (k, v) in template.module.__dict__.items() if not k.startswith('_'))
+        for k, v in all_vars.items():
             # If we were operating on specified globals, munge those instead of notebook globals
             if top_env_var.get(k):
                 top_env_var[k] = v
@@ -208,7 +208,7 @@ class JinjaMagics(Magics):
     # ...with a few exceptions.
     extra_name_set = frozenset({"In", "Out", "__", "___", "_i", "_ii", "_iii"})
 
-    def get_jinja_vars(self, top_vars):
+    def get_jinja_vars(self, top_vars) -> Mapping[str, Any]:
         """Pull a fine selection of notebook variables into the Jinja namespace"""
         user_vars = dict((k, v) for (k, v) in self.shell.user_ns.items()
                          if not k.startswith('_')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 
 setup(
     name="jinja-yaml-magic",
-    version="0.1.2",
+    version="0.2.0a1",
     packages=find_packages(),
 
     # package_data={
@@ -27,6 +27,10 @@ setup(
     long_description_content_type='text/markdown',
 
     install_requires=requirements,
+
+    extras_require={
+        "ansible": ["ansible-core>=2.12.1"],
+    },
 
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This adds a loader for Ansible's built-in filters. Make sure you have `ansible-core` installed in your environment, and then run this in a cell:

```jupyter
%jinja_load_ansible
```

This adds all the Ansible filters to the new notebook variable `ansible_filters`, a dictionary used for filter lookup in all `%jinja` invocations.

To test Ansible plugins, run something like

```jinja
%%jinja
{{ ""|md5 }}
```

`%jinja_load_ansible` takes one optional argument: a directory to search for additional Ansible plugins. 

